### PR TITLE
Add Ash CreativeModeTab abstraction

### DIFF
--- a/Common/src/main/java/net/dodogang/ash/item/api/CreativeModeTabBuilder.java
+++ b/Common/src/main/java/net/dodogang/ash/item/api/CreativeModeTabBuilder.java
@@ -1,0 +1,42 @@
+package net.dodogang.ash.item.api;
+
+import net.dodogang.ash.impl.ImplLoader;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class CreativeModeTabBuilder {
+    private static final CreativeModeTabBuilder IMPL = ImplLoader.load(CreativeModeTabBuilder.class);
+
+    public static Builder create(ResourceLocation resLoc) {
+        return IMPL.createImpl(resLoc);
+    }
+
+    protected abstract Builder createImpl(ResourceLocation resLoc);
+
+    public static abstract class Builder {
+        protected final ResourceLocation resLoc;
+        protected Supplier<ItemStack> iconSupplier = () -> ItemStack.EMPTY;
+        protected Consumer<List<ItemStack>> stacksForDisplay;
+
+        protected Builder(ResourceLocation resLoc) {
+            this.resLoc = resLoc;
+        }
+
+        public Builder icon(Supplier<ItemStack> iconSupplier) {
+            this.iconSupplier = iconSupplier;
+            return this;
+        }
+
+        public Builder appendItems(Consumer<List<ItemStack>> stacksForDisplay) {
+            this.stacksForDisplay = stacksForDisplay;
+            return this;
+        }
+
+        public abstract CreativeModeTab build();
+    }
+}

--- a/Common/src/main/resources/META-INF/services/net.dodogang.ash.item.api.CreativeModeTabBuilder
+++ b/Common/src/main/resources/META-INF/services/net.dodogang.ash.item.api.CreativeModeTabBuilder
@@ -1,0 +1,1 @@
+net.dodogang.ash.item.impl.CreativeModeTabBuilderImpl

--- a/Fabric/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
+++ b/Fabric/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
@@ -1,0 +1,27 @@
+package net.dodogang.ash.item.impl;
+
+import net.dodogang.ash.item.api.CreativeModeTabBuilder;
+import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+
+public class CreativeModeTabBuilderImpl extends CreativeModeTabBuilder {
+    @Override
+    protected Builder createImpl(ResourceLocation resLoc) {
+        return new BuilderImpl(resLoc);
+    }
+
+    private static class BuilderImpl extends Builder {
+        private BuilderImpl(ResourceLocation resLoc) {
+            super(resLoc);
+        }
+
+        @Override
+        public CreativeModeTab build() {
+            return FabricItemGroupBuilder.create(resLoc)
+                    .icon(iconSupplier)
+                    .appendItems(stacksForDisplay)
+                    .build();
+        }
+    }
+}

--- a/Forge/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
+++ b/Forge/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
@@ -1,0 +1,38 @@
+package net.dodogang.ash.item.impl;
+
+import net.dodogang.ash.item.api.CreativeModeTabBuilder;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+
+public class CreativeModeTabBuilderImpl extends CreativeModeTabBuilder {
+    @Override
+    protected Builder createImpl(ResourceLocation resLoc) {
+        return new BuilderImpl(resLoc);
+    }
+
+    private static class BuilderImpl extends Builder {
+        private BuilderImpl(ResourceLocation resLoc) {
+            super(resLoc);
+        }
+
+        @Override
+        public CreativeModeTab build() {
+            return new CreativeModeTab(String.format("%s.%s", resLoc.getNamespace(), resLoc.getPath())) {
+                @Override
+                public ItemStack makeIcon() {
+                    return iconSupplier.get();
+                }
+
+                @Override
+                public void fillItemList(NonNullList<ItemStack> stacks) {
+                    super.fillItemList(stacks);
+                    if (stacksForDisplay != null) {
+                        stacksForDisplay.accept(stacks);
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Quilt/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
+++ b/Quilt/src/main/java/net/dodogang/ash/item/impl/CreativeModeTabBuilderImpl.java
@@ -1,0 +1,27 @@
+package net.dodogang.ash.item.impl;
+
+import net.dodogang.ash.item.api.CreativeModeTabBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import org.quiltmc.qsl.item.group.api.QuiltItemGroup;
+
+public class CreativeModeTabBuilderImpl extends CreativeModeTabBuilder {
+    @Override
+    protected Builder createImpl(ResourceLocation resLoc) {
+        return new BuilderImpl(resLoc);
+    }
+
+    private static class BuilderImpl extends Builder {
+        private BuilderImpl(ResourceLocation resLoc) {
+            super(resLoc);
+        }
+
+        @Override
+        public CreativeModeTab build() {
+            return QuiltItemGroup.builder(resLoc)
+                    .icon(iconSupplier)
+                    .appendItems(stacksForDisplay)
+                    .build();
+        }
+    }
+}

--- a/common/src/main/java/net/dodogang/crumbs/Crumbs.java
+++ b/common/src/main/java/net/dodogang/crumbs/Crumbs.java
@@ -1,12 +1,23 @@
 package net.dodogang.crumbs;
 
+import net.dodogang.ash.item.api.CreativeModeTabBuilder;
 import net.dodogang.ash.loader.api.ModLoader;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class Crumbs {
     public static final String MOD_ID = "crumbs";
     public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
+
+    public static final CreativeModeTab CRUMBS_TAB = CreativeModeTabBuilder
+            .create(new ResourceLocation(MOD_ID, "crumbs"))
+            .icon(() -> new ItemStack(Blocks.MANGROVE_LOG))
+            .appendItems(stacksForDisplay -> stacksForDisplay.add(new ItemStack(Blocks.MANGROVE_LOG)))
+            .build();
 
     public static void initialize() {
         LOGGER.info("getName: " + ModLoader.getName());


### PR DESCRIPTION
This PR adds `CreativeModeTabBuilder` which supplies the user with the following methods:
- `create(ResourceLocation)` creates the `Builder` with a given id required for fabric and quilt Impls.
- `icon(Supplier<ItemStack>)` provides the `CreativeModeTab` with the icon. Because it's a supplier, the icon can change dynamically.
- `appendItem(Consumer<Set<ItemStack>>)` provides the user with the set of items already in the tab which the user can append to.
- `build()` goes through each platform's own `CreativeModeTab` abstraction to create a `CreativeModeTab`. (`FabricItemGroupBuilder`, forge's `CreativeModeTab` patches, and `QuiltItemGroup`)

## Missing Features
Forge doesn't add any features on top of Vanilla.

All of Fabric's custom non-deprecated features are covered here (`icon` and `appendItem`).

Quilt adds two features that aren't supported by this. However, I don't think there's any reason to add them.
- `setIcon` allows you to change the icon after the creative tab has been created. However, the icons already use suppliers which allow this.
- `displayText` allows you to set the text that renders when hovering over the tab when creating the tab. However, this can just be done through the localized name.

## Discussion Question
Is `CreativeModeTabBuilder` an appropriate name? It's kind of long and isn't technically correct because the actual builder is an internal class `Builder` inside of `CreativeModeTabBuilder`.

Another option is `AshCreativeModeTab`, but that wouldn't be technically correct either because it wouldn't extend `CreativeModeTab`.